### PR TITLE
fix bug: get wrong actions after step() and step_back() in Doudizhu.

### DIFF
--- a/rlcard/games/doudizhu/player.py
+++ b/rlcard/games/doudizhu/player.py
@@ -60,7 +60,7 @@ class DoudizhuPlayer(object):
         '''
 
         actions = []
-        if greater_player is None or greater_player is self:
+        if greater_player is None or greater_player.player_id == self.player_id:
             actions = judger.get_playable_cards(self)
         else:
             actions = get_gt_cards(self, greater_player)

--- a/tests/games/test_doudizhu_game.py
+++ b/tests/games/test_doudizhu_game.py
@@ -78,6 +78,20 @@ class TestDoudizhuGame(unittest.TestCase):
         self.assertEqual(game.state, state)
         self.assertEqual(game.step_back(), False)
 
+        #actions should be the same after step_back()
+        game = Game(allow_step_back=True)
+        state, player_id = game.init_game()
+        action = state['actions'][0]
+        game.step(action)
+        game.step('pass')
+        game.step('pass')
+        actions = game.state['actions']
+        game.step(actions[0])
+        game.step_back()
+        actions.sort()
+        game.state['actions'].sort()
+        self.assertEqual(game.state['actions'], actions)
+
     def test_get_landlord_score(self):
         score_1 = get_landlord_score('56888TTQKKKAA222R')
         self.assertEqual(score_1, 12)


### PR DESCRIPTION
    Doudizhu.game.round.greater_player refered to the same object of doudizhu.game.players[current_player]  before step_back but are different objects after step_back() because step() used deepcopy to record "players" and "round".
    So "greater_player is players[current_player]" will be False in player.available_actions and this will cause game.get_state()  get the wrong actions.

    Use "greater_player.player_id == players[current_player]" to compare the two players and added unittest for it.