### PR TITLE
performance improvement for step_back

### DIFF
--- a/rlcard/games/doudizhu/dealer.py
+++ b/rlcard/games/doudizhu/dealer.py
@@ -38,8 +38,9 @@ class DoudizhuDealer(object):
         '''
         hand_num = (len(self.deck) - 3) // len(players)
         for index, player in enumerate(players):
-            player.current_hand = self.deck[index*hand_num:(index+1)*hand_num]
-            player.current_hand.sort(key=functools.cmp_to_key(doudizhu_sort_card))
+            current_hand = self.deck[index*hand_num:(index+1)*hand_num]
+            current_hand.sort(key=functools.cmp_to_key(doudizhu_sort_card))
+            player.set_current_hand(current_hand)
             player.initial_hand = cards2str(player.current_hand)
 
     def determine_role(self, players):

--- a/rlcard/games/doudizhu/judger.py
+++ b/rlcard/games/doudizhu/judger.py
@@ -16,6 +16,7 @@ class DoudizhuJudger(object):
         '''
         all_cards_list = CARD_TYPE[1]
         self.playable_cards = [set() for _ in range(3)]
+        self._recorded_removed_playable_cards = [[] for _ in range(3)]
         for player in players:
             player_id = player.player_id
             current_hand = cards2str(player.current_hand)
@@ -23,8 +24,8 @@ class DoudizhuJudger(object):
                 if contains_cards(current_hand, cards):
                     self.playable_cards[player_id].add(cards)
 
-    def get_playable_cards(self, player):
-        ''' Provide all legal cards the player can play according to his
+    def calc_playable_cards(self, player):
+        ''' Recalculate all legal cards the player can play according to his
         current hand.
 
         Args:
@@ -35,6 +36,8 @@ class DoudizhuJudger(object):
         Returns:
             list: list of string of playable cards
         '''
+        removed_playable_cards = []
+
         player_id = player.player_id
         current_hand = cards2str(player.current_hand)
         missed = None
@@ -50,13 +53,41 @@ class DoudizhuJudger(object):
             player.singles = player.singles[position+1:]
             for cards in playable_cards:
                 if missed in cards or (not contains_cards(current_hand, cards)):
+                    removed_playable_cards.append(cards)
                     self.playable_cards[player_id].remove(cards)
         else:
             for cards in playable_cards:
                 if not contains_cards(current_hand, cards):
                     #del self.playable_cards[player_id][cards]
+                    removed_playable_cards.append(cards)
                     self.playable_cards[player_id].remove(cards)
+        self._recorded_removed_playable_cards[player_id].append(removed_playable_cards)
         return self.playable_cards[player_id]
+
+    def restore_playable_cards(self, player_id):
+        ''' restore playable_cards for judger for game.step_back().
+            
+        Args:
+            player_id: The id of the player whose playable_cards need to be restored
+        '''
+        removed_playable_cards = self._recorded_removed_playable_cards[player_id].pop()
+        self.playable_cards[player_id].update(removed_playable_cards)
+            
+
+    def get_playable_cards(self, player):
+        ''' Provide all legal cards the player can play according to his
+        current hand.
+
+        Args:
+            player (DoudizhuPlayer object): object of DoudizhuPlayer
+            init_flag (boolean): For the first time, set it True to accelerate
+              the preocess.
+
+        Returns:
+            list: list of string of playable cards
+        '''
+        return self.playable_cards[player.player_id]
+
 
     @staticmethod
     def judge_game(players, player_id):

--- a/rlcard/games/doudizhu/round.py
+++ b/rlcard/games/doudizhu/round.py
@@ -62,3 +62,27 @@ class DoudizhuRound(object):
         self.update_public(action)
         self.greater_player = player.play(action, self.greater_player)
         return self.greater_player
+
+    def find_last_greater_player_id_in_trace(self):
+        ''' Find the last greater_player's id in trace
+
+        Returns:
+            the last greater_player's id in trace
+        '''
+        for i in range(len(self.trace) - 1, -1, -1):
+            id, action = self.trace[i]
+            if (action != 'pass'):
+                return id
+        return None
+
+    def find_last_played_cards_in_trace(self, player_id):
+        ''' Find the player_id's last played_cards in trace
+
+        Returns:
+            The player_id's last played_cards in trace
+        '''
+        for i in range(len(self.trace) - 1, -1, -1):
+            id, action = self.trace[i]
+            if (id == player_id and action != 'pass'):
+                return action
+        return None


### PR DESCRIPTION
Tried cfr on the doudizhu and find 78.8% time was on the deepcopy which is used to record objects for later step_back use.
The main changes here are:
    1. remove deepcopy
	2. for some simple objects like game.winner_id and game.round.greater_player etc, use information in trace to restore them
	3. for player.current_hand and judger.playable_cards, save the removed objects for each step() action and restore them when step_back()

problems:
    Will save removed objects of player.current_hand and judger.playable_cards even game.allow_step_back not set