### PR TITLE
fix TypeError pytorch GPU

### DIFF
--- a/rlcard/agents/dqn_agent_pytorch.py
+++ b/rlcard/agents/dqn_agent_pytorch.py
@@ -288,7 +288,7 @@ class Estimator(object):
         '''
         with torch.no_grad():
             s = torch.from_numpy(s).float().to(self.device)
-            q_as = self.qnet(s).numpy()
+            q_as = self.qnet(s).cpu().numpy()
         return q_as
 
     def update(self, s, a, y):


### PR DESCRIPTION
Fix a type error when run pytorch dqn on GPU.
TypeError: can't convert CUDA tensor to numpy.