### PR TITLE
Corrections for Gin Rummy.

### DIFF
--- a/docs/games.md
+++ b/docs/games.md
@@ -352,9 +352,9 @@ The reward is calculated by the terminal state of the game.
 Note that the reward is different from that of the standard game.
 A player who gins is awarded 1 point.
 A player who knocks is awarded 0.2 points.
-The losing player is punished by the negative of their deadwood count.
+The losing player is punished by the negative of their deadwood count divided by 100.
 
-If the hand is declared dead, both players are punished by the negative of their deadwood count.
+If the hand is declared dead, both players are punished by the negative of their deadwood count divided by 100.
 
 ### Settings
 

--- a/rlcard/games/gin_rummy/player.py
+++ b/rlcard/games/gin_rummy/player.py
@@ -62,6 +62,7 @@ class GinRummyPlayer(object):
 
     def did_populate_hand(self):
         self.meld_kinds_by_rank_id = [[] for _ in range(13)]
+        self.meld_run_by_suit_id = [[] for _ in range(4)]
         all_set_melds = melding.get_all_set_melds(hand=self.hand)
         for set_meld in all_set_melds:
             rank_id = utils.get_rank_id(set_meld[0])


### PR DESCRIPTION
You need to change the web page http://rlcard.org/games.html to match the changes to docs/games.md about the following two items:

1) The losing player is punished by the negative of their deadwood count divided by 100.

2) If the hand is declared dead, both players are punished by the negative of their deadwood count divided by 100.