### PR TITLE
Implement multiple agent for blackjack

### DIFF
--- a/examples/blackjack_human.py
+++ b/examples/blackjack_human.py
@@ -3,14 +3,17 @@
 '''
 
 import rlcard
+from rlcard.agents import RandomAgent as RandomAgent
 from rlcard.agents import BlackjackHumanAgent as HumanAgent
 from rlcard.utils.utils import print_card
 
 # Make environment and enable human mode
 # Set 'record_action' to True because we need it to print results
-env = rlcard.make('blackjack', config={'record_action': True})
+num_players = 2
+env = rlcard.make('blackjack', config={'record_action': True, 'num_players': num_players})
 human_agent = HumanAgent(env.action_num)
-env.set_agents([human_agent])
+random_agent = RandomAgent(env.action_num)
+env.set_agents([human_agent, random_agent])
 
 print(">> Blackjack human agent")
 
@@ -20,29 +23,40 @@ while (True):
     trajectories, payoffs = env.run(is_training=False)
     # If the human does not take the final action, we need to
     # print other players action
+
     if len(trajectories[0]) != 0:
-        final_state = trajectories[0][-1][-2]
-        action_record = final_state['action_record']
-        state = final_state['raw_obs']
+        final_state = []
+        action_record = []
+        state = []
         _action_list = []
-        for i in range(1, len(action_record)+1):
+
+        for i in range(num_players):
+            final_state.append(trajectories[i][-1][-2])
+            state.append(final_state[i]['raw_obs'])
+
+        action_record.append(final_state[i]['action_record'])
+        for i in range(1, len(action_record) + 1):
             _action_list.insert(0, action_record[-i])
-        for pair in _action_list:
+
+        for pair in _action_list[0]:
             print('>> Player', pair[0], 'chooses', pair[1])
 
     # Let's take a look at what the agent card is
     print('===============   Dealer hand   ===============')
-    print_card(state['state'][1])
-    print('===============    Your Hand    ===============')
-    print_card(state['state'][0])
+    print_card(state[0]['state'][1])
+
+    for i in range(num_players):
+        print('===============   Player {} Hand   ==============='.format(i))
+        print_card(state[i]['state'][0])
 
     print('===============     Result     ===============')
-    if payoffs[0] > 0:
-        print('You win {} chips!'.format(payoffs[0]))
-    elif payoffs[0] == 0:
-        print('It is a tie.')
-    else:
-        print('You lose {} chips!'.format(-payoffs[0]))
-    print('')
+    for i in range(num_players):
+        if payoffs[i] == 1:
+            print('Player {} win {} chip!'.format(i, payoffs[i]))
+        elif payoffs[i] == 0:
+            print('Player {} is tie'.format(i))
+        else:
+            print('Player {} lose {} chip!'.format(i, -payoffs[i]))
+        print('')
 
     input("Press any key to continue...")

--- a/rlcard/agents/blackjack_human_agent.py
+++ b/rlcard/agents/blackjack_human_agent.py
@@ -57,9 +57,14 @@ def _print_state(state, raw_legal_actions, action_record):
         print('>> Player', pair[0], 'chooses', pair[1])
 
     print('\n=============   Dealer Hand   ===============')
-    print_card(state['state'][1])
-    print('===============    Your Hand    ===============')
-    print_card(state['state'][0])
+    print_card(state['dealer hand'])
+
+    num_player = len(state) - 3
+
+    for i in range(num_player):
+        print('===============   Player {} Hand   ==============='.format(i))
+        print_card(state['player' + str(i) + ' hand'])
+
     print('\n=========== Actions You Can Choose ===========')
     print(', '.join([str(index) + ': ' + action for index, action in enumerate(raw_legal_actions)]))
     print('')

--- a/rlcard/envs/blackjack.py
+++ b/rlcard/envs/blackjack.py
@@ -11,7 +11,7 @@ class BlackjackEnv(Env):
     def __init__(self, config):
         ''' Initialize the Blackjack environment
         '''
-        self.game = Game()
+        self.game = Game(num_players=config['num_players'])
         super().__init__(config)
         self.rank2score = {"A":11, "2":2, "3":3, "4":4, "5":5, "6":6, "7":7, "8":8, "9":9, "T":10, "J":10, "Q":10, "K":10}
         self.actions = ['hit', 'stand']
@@ -71,12 +71,18 @@ class BlackjackEnv(Env):
         Returns:
            payoffs (list): list of payoffs
         '''
-        if self.game.winner['player'] == 0 and self.game.winner['dealer'] == 1:
-            return np.array([-1])
-        elif self.game.winner['dealer'] == 0 and self.game.winner['player'] == 1:
-            return np.array([1])
-        elif self.game.winner['player'] == 1 and self.game.winner['dealer'] == 1:
-            return np.array([0])
+        payoffs = []
+
+        for i in range(self.num_players):
+            if self.game.winner['player' + str(i)] == 2:
+                payoffs.append(1)  # Dealer bust or player get higher score than dealer
+            elif self.game.winner['player' + str(i)] == 1:
+                payoffs.append(0)  # Dealer and player tie
+            else:
+                payoffs.append(-1)  # Player bust or Dealer get higher score than player
+
+        return np.array(payoffs)
+
 
     def _decode_action(self, action_id):
         ''' Decode the action for applying to the game

--- a/rlcard/envs/env.py
+++ b/rlcard/envs/env.py
@@ -57,6 +57,9 @@ class Env(object):
         # Set random seed, default is None
         self._seed(config['seed'])
 
+        # Set player number, default is 1
+        self.num_players = config['num_players']
+
     def reset(self):
         '''
         Reset environment in single-agent mode

--- a/rlcard/envs/registration.py
+++ b/rlcard/envs/registration.py
@@ -10,6 +10,7 @@ DEFAULT_CONFIG = {
         'record_action' : False,
         'seed': None,
         'env_num': 1,
+        'num_players': 1,
         }
 
 class EnvSpec(object):

--- a/rlcard/games/blackjack/game.py
+++ b/rlcard/games/blackjack/game.py
@@ -7,11 +7,12 @@ from rlcard.games.blackjack import Judger
 
 class BlackjackGame(object):
 
-    def __init__(self, allow_step_back=False):
+    def __init__(self, allow_step_back=False, num_players = 1):
         ''' Initialize the class Blackjack Game
         '''
         self.allow_step_back = allow_step_back
         self.np_random = np.random.RandomState()
+        self.num_players = num_players
 
     def init_game(self):
         ''' Initialilze the game
@@ -21,17 +22,31 @@ class BlackjackGame(object):
             player_id (int): current player's id
         '''
         self.dealer = Dealer(self.np_random)
-        self.player = Player(0, self.np_random)
+
+        self.player = []
+        for i in range(self.num_players):
+            self.player.append(Player(i, self.np_random))
+
         self.judger = Judger(self.np_random)
-        self.dealer.deal_card(self.player)
-        self.dealer.deal_card(self.dealer)
-        self.dealer.deal_card(self.player)
-        self.dealer.deal_card(self.dealer)
-        self.player.status, self.player.score = self.judger.judge_round(self.player)
+
+        for i in range(2):
+            for j in range(self.num_players):
+                self.dealer.deal_card(self.player[j])
+            self.dealer.deal_card(self.dealer)
+
+        for i in range(self.num_players):
+            self.player[i].status, self.player[i].score = self.judger.judge_round(self.player[i])
+
         self.dealer.status, self.dealer.score = self.judger.judge_round(self.dealer)
-        self.winner = {'dealer':0, 'player':0}
+
+        self.winner = {'dealer': 0}
+        for i in range(self.num_players):
+            self.winner['player' + str(i)] = 0
+
         self.history = []
-        return self.get_state(self.get_player_id()), self.get_player_id()
+        self.game_pointer = 0
+
+        return self.get_state(self.game_pointer), self.game_pointer
 
     def step(self, action):
         ''' Get the next state
@@ -44,40 +59,47 @@ class BlackjackGame(object):
             int: next plater's id
         '''
         if self.allow_step_back:
-            p = deepcopy(self.player)
+            p = deepcopy(self.player[self.game_pointer])
             d = deepcopy(self.dealer)
             w = deepcopy(self.winner)
-            self.history.append((d,p,w))
+            self.history.append((d, p, w))
 
         next_state = {}
         # Play hit
         if action != "stand":
-            self.dealer.deal_card(self.player)
-            self.player.status, self.player.score = self.judger.judge_round(self.player)
-
-            if self.player.status == 'bust':
+            self.dealer.deal_card(self.player[self.game_pointer])
+            self.player[self.game_pointer].status, self.player[self.game_pointer].score = self.judger.judge_round(
+                self.player[self.game_pointer])
+            if self.player[self.game_pointer].status == 'bust':
                 # game over, set up the winner, print out dealer's hand
-                self.judger.judge_game(self)
-                dealer_hand = [card.get_index() for card in self.dealer.hand]
-            else:
-                # game continue, hide the first card of dealer's hand
-                dealer_hand = [card.get_index() for card in self.dealer.hand[1:]]
-
-            hand = [card.get_index() for card in self.player.hand]
-            next_state['state'] = (hand, dealer_hand)
-            next_state['actions'] = ('hit', 'stand')
-
+                self.judger.judge_game(self, self.game_pointer)
         elif action == "stand":
-
             while self.judger.judge_score(self.dealer.hand) < 17:
                 self.dealer.deal_card(self.dealer)
                 self.dealer.status, self.dealer.score = self.judger.judge_round(self.dealer)
-            self.judger.judge_game(self)
-            hand = [card.get_index() for card in self.player.hand]
-            dealer_hand = [c.get_index() for c in self.dealer.hand]
-            next_state['state'] = (hand, dealer_hand) # show all hand of dealer
-            next_state['actions'] = ('hit', 'stand')
-        return next_state, self.player.get_player_id()
+            self.player[self.game_pointer].status, self.player[self.game_pointer].score = self.judger.judge_round(
+                self.player[self.game_pointer])
+            self.judger.judge_game(self, self.game_pointer)
+
+        hand = [card.get_index() for card in self.player[self.game_pointer].hand]
+
+        if self.is_over():
+            dealer_hand = [card.get_index() for card in self.dealer.hand]
+        else:
+            dealer_hand = [card.get_index() for card in self.dealer.hand[1:]]
+
+        for i in range(self.num_players):
+            next_state['player' + str(i) + ' hand'] = [card.get_index() for card in self.player[i].hand]
+        next_state['dealer hand'] = dealer_hand
+        next_state['actions'] = ('hit', 'stand')
+        next_state['state'] = (hand, dealer_hand)
+
+        if self.game_pointer >= self.num_players - 1:
+            self.game_pointer = 0
+        else:
+            self.game_pointer += 1
+
+        return next_state, self.game_pointer
 
     def step_back(self):
         ''' Return to the previous state of the game
@@ -87,18 +109,17 @@ class BlackjackGame(object):
         '''
         #while len(self.history) > 0:
         if len(self.history) > 0:
-            self.dealer, self.player, self.winner = self.history.pop()
+            self.dealer, self.player[self.game_pointer], self.winner = self.history.pop()
             return True
         return False
 
-    @staticmethod
-    def get_player_num():
+    def get_player_num(self):
         ''' Return the number of players in blackjack
 
         Returns:
             number_of_player (int): blackjack only have 1 player
         '''
-        return 1
+        return self.num_players
 
     @staticmethod
     def get_action_num():
@@ -115,9 +136,9 @@ class BlackjackGame(object):
         Returns:
             player_id (int): current player's id
         '''
-        return self.player.get_player_id()
+        return self.game_pointer
 
-    def get_state(self, player):
+    def get_state(self, player_id):
         ''' Return player's state
 
         Args:
@@ -126,14 +147,25 @@ class BlackjackGame(object):
         Returns:
             state (dict): corresponding player's state
         '''
+        '''
+                before change state only have two keys (action, state)
+                but now have more than 4 keys (action, state, player0 hand, player1 hand, ... , dealer hand)
+                Although key 'state' have duplicated information with key 'player hand' and 'dealer hand', I couldn't remove it because of other codes
+                To remove it, we need to change dqn agent too in my opinion
+                '''
         state = {}
         state['actions'] = ('hit', 'stand')
-        hand = [card.get_index() for card in self.player.hand]
-        if self.winner['player'] == 0 and self.winner['dealer'] == 0:
-            dealer_hand = [card.get_index() for card in self.dealer.hand[1:]]
-        else:
+        hand = [card.get_index() for card in self.player[player_id].hand]
+        if self.is_over():
             dealer_hand = [card.get_index() for card in self.dealer.hand]
+        else:
+            dealer_hand = [card.get_index() for card in self.dealer.hand[1:]]
+
+        for i in range(self.num_players):
+            state['player' + str(i) + ' hand'] = [card.get_index() for card in self.player[i].hand]
+        state['dealer hand'] = dealer_hand
         state['state'] = (hand, dealer_hand)
+
         return state
 
     def is_over(self):
@@ -142,10 +174,14 @@ class BlackjackGame(object):
         Returns:
             status (bool): True/False
         '''
-        if self.player.status == 'bust'or self.dealer.status == 'bust' or (self.winner['dealer'] != 0 or self.winner['player'] != 0):
-            return True
-        else:
-            return False
+        '''
+                I should change here because judger and self.winner is changed too
+                '''
+        for i in range(self.num_players):
+            if self.winner['player' + str(i)] == 0:
+                return False
+
+        return True
 
 
 ##########################################################

--- a/rlcard/games/blackjack/judger.py
+++ b/rlcard/games/blackjack/judger.py
@@ -22,25 +22,34 @@ class BlackjackJudger(object):
         else:
             return "bust", score
 
-    @staticmethod
-    def judge_game(game):
+    def judge_game(self, game, game_pointer):
         ''' Judge the winner of the game
 
         Args:
             game (class): target game class
         '''
-        if game.player.status == 'bust':
-            game.winner['dealer'] = 1
+        '''
+                game.winner['dealer'] doesn't need anymore if we change code like this
+
+                player bust (whether dealer bust or not) => game.winner[playerX] = -1
+                player and dealer tie => game.winner[playerX] = 1
+                dealer bust and player not bust => game.winner[playerX] = 2
+                player get higher score than dealer => game.winner[playerX] = 2
+                dealer get higher score than player => game.winner[playerX] = -1
+                game.winner[playerX] = 0 => the game is still ongoing
+                '''
+
+        if game.player[game_pointer].status == 'bust':
+            game.winner['player' + str(game_pointer)] = -1
         elif game.dealer.status == 'bust':
-            game.winner['player'] = 1
+            game.winner['player' + str(game_pointer)] = 2
         else:
-            if game.player.score > game.dealer.score:
-                game.winner['player'] = 1
-            elif game.player.score < game.dealer.score:
-                game.winner['dealer'] = 1
+            if game.player[game_pointer].score > game.dealer.score:
+                game.winner['player' + str(game_pointer)] = 2
+            elif game.player[game_pointer].score < game.dealer.score:
+                game.winner['player' + str(game_pointer)] = -1
             else:
-                game.winner['dealer'] = 1
-                game.winner['player'] = 1
+                game.winner['player' + str(game_pointer)] = 1
 
     def judge_score(self, cards):
         ''' Judge the score of a given cards set


### PR DESCRIPTION
Add key 'num_players' to config (default = 1)
Payoffs return a list of numpy array
Add key 'player(0, 1, 2, ...) hand' and 'dealer hand' to state
Other blackjack examples are tested and works well too like random, DQN

Although DQN agent is only available in a single agent game now, as you said if you change _extracted_state and DQN agent, maybe it will available on multiple agent mode in my opinion :)
