### PR TITLE
misspelled word in env.py

### DIFF
--- a/rlcard/envs/env.py
+++ b/rlcard/envs/env.py
@@ -14,8 +14,8 @@ class Env(object):
             config (dict): A config dictionary. All the fields are
                 optional. Currently, the dictionary includes:
                 'seed' (int) - A environment local random seed.
-                'env_num' (int) - If env_num>1, the environemnt wil be run
-                  with multiple processes. Note the implementatino is
+                'env_num' (int) - If env_num>1, the environment wil be run
+                  with multiple processes. Note the implementation is
                   in `vec_env.py`.
                 'allow_step_back' (boolean) - True if allowing
                  step_back.


### PR DESCRIPTION
There are two misspelled words in [env.py](https://github.com/datamllab/rlcard/blob/master/rlcard/envs/env.py) comments.
line 17 : ```environemnt -> environment```
line 18: ```implementatino -> implementation```
Thank you for this package and sorry for this minor PR.