### PR TITLE
Small setup.py fix

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ setuptools.setup(
         'packaging',
     ],
     extras_require=extras,
-    requires_python='>=3.5',
+    requires_python='>=3.6',
     classifiers=[
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.7",


### PR DESCRIPTION
You guys have seemingly removed support for Python 3.5 (you don't test for it or list it as a supported version), which is now end-of-life. However, setup.py still listed a minimum install version of 3.5. this fixes that.