### PR TITLE
Fix some typos and wrong type annotations in DQN agents.

### DIFF
--- a/rlcard/agents/dqn_agent.py
+++ b/rlcard/agents/dqn_agent.py
@@ -61,7 +61,7 @@ class DQNAgent(object):
             sess (tf.Session): Tensorflow Session object.
             scope (string): The name scope of the DQN agent.
             replay_memory_size (int): Size of the replay memory
-            replay_memory_init_size (int): Number of random experiences to sampel when initializing
+            replay_memory_init_size (int): Number of random experiences to sample from when initializing
               the reply memory.
             train_every (int): Train the agent every X steps.
             update_target_estimator_every (int): Copy parameters from the Q estimator to the

--- a/rlcard/agents/dqn_agent.py
+++ b/rlcard/agents/dqn_agent.py
@@ -67,9 +67,9 @@ class DQNAgent(object):
             update_target_estimator_every (int): Copy parameters from the Q estimator to the
               target estimator every N steps
             discount_factor (float): Gamma discount factor
-            epsilon_start (int): Chance to sample a random action when taking an action.
+            epsilon_start (float): Chance to sample a random action when taking an action.
               Epsilon is decayed over time and this is the start value
-            epsilon_end (int): The final minimum value of epsilon after decaying is done
+            epsilon_end (float): The final minimum value of epsilon after decaying is done
             epsilon_decay_steps (int): Number of steps to decay epsilon over
             batch_size (int): Size of batches to sample from the replay memory
             evaluate_every (int): Evaluate every N steps

--- a/rlcard/agents/dqn_agent_pytorch.py
+++ b/rlcard/agents/dqn_agent_pytorch.py
@@ -66,7 +66,7 @@ class DQNAgent(object):
         Args:
             scope (str): The name of the DQN agent
             replay_memory_size (int): Size of the replay memory
-            replay_memory_init_size (int): Number of random experiences to sampel when initializing
+            replay_memory_init_size (int): Number of random experiences to sample when initializing
               the reply memory.
             update_target_estimator_every (int): Copy parameters from the Q estimator to the
               target estimator every N steps

--- a/rlcard/agents/dqn_agent_pytorch.py
+++ b/rlcard/agents/dqn_agent_pytorch.py
@@ -71,9 +71,9 @@ class DQNAgent(object):
             update_target_estimator_every (int): Copy parameters from the Q estimator to the
               target estimator every N steps
             discount_factor (float): Gamma discount factor
-            epsilon_start (int): Chance to sample a random action when taking an action.
+            epsilon_start (float): Chance to sample a random action when taking an action.
               Epsilon is decayed over time and this is the start value
-            epsilon_end (int): The final minimum value of epsilon after decaying is done
+            epsilon_end (float): The final minimum value of epsilon after decaying is done
             epsilon_decay_steps (int): Number of steps to decay epsilon over
             batch_size (int): Size of batches to sample from the replay memory
             evaluate_every (int): Evaluate every N steps


### PR DESCRIPTION
There were typos in DQN agents' description of `replay_memory_init_size`.
And the type annotations of `epsilon_start` and `epsilon_end` should be `float` instead of `int`.