### PR TITLE
Config num_players for holdem environments

### DIFF
--- a/rlcard/envs/nolimitholdem.py
+++ b/rlcard/envs/nolimitholdem.py
@@ -22,6 +22,8 @@ class NolimitholdemEnv(Env):
         ''' Initialize the Limitholdem environment
         '''
         self.name = 'no-limit-holdem'
+        # 'chips_for_each' must have num_players length
+        DEFAULT_GAME_CONFIG['chips_for_each'] = [100] * config['game_num_players']
         self.default_game_config = DEFAULT_GAME_CONFIG
         self.game = Game()
         super().__init__(config)

--- a/rlcard/games/leducholdem/judger.py
+++ b/rlcard/games/leducholdem/judger.py
@@ -20,22 +20,32 @@ class LeducholdemJudger:
             (list): Each entry of the list corresponds to one entry of the
         '''
         # Judge who are the winners
-        winners = [0, 0]
-        # If one player folds, the other player is the winner
+        winners = [0] * len(players)
+        fold_count = 0
+        ranks = []
+        # If every player folds except one, the alive player is the winner
         for idx, player in enumerate(players):
-                if player.status == 'folded':
-                    winners[(idx+1)%2] = 1
-                    break
-        if sum(winners) < 1:
-            if players[0].hand.rank == players[1].hand.rank:
-                winners = [1, 1]
+            ranks.append(rank2int(player.hand.rank))
+            if player.status == 'folded':
+               fold_count += 1
+            elif player.status == 'alive':
+                alive_idx = idx
+        if fold_count == (len(players) - 1):
+            winners[alive_idx] = 1
+        
+        # If any of the players matches the public card wins
         if sum(winners) < 1:
             for idx, player in enumerate(players):
                 if player.hand.rank == public_card.rank:
                     winners[idx] = 1
                     break
+        
+        # If non of the above conditions, the winner player is the one with the highest card rank
         if sum(winners) < 1:
-            winners = [1, 0] if rank2int(players[0].hand.rank) > rank2int(players[1].hand.rank) else [0, 1]
+            max_rank = max(ranks)
+            max_index = [i for i, j in enumerate(ranks) if j == max_rank]
+            for idx in max_index:
+                winners[idx] = 1
 
         # Compute the total chips
         total = 0


### PR DESCRIPTION
This PR fixes two holdem games for adding extra players:

- Leduc Holdem: the reward judger for leduc was only considering two player games. After this fixes more than two players can be added to the game.
- Nolimitholdem: when adding extra players the default configuration for chips for each player didn't change and would only consider two player games as well. This PR expands the default chips list to the desired number of players