### PR TITLE
Update tested python versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 language: python
 python:
-  - "3.6"
   - "3.7"
+  - "3.8"
+  - "3.9"
 install: 
   - pip install -e .[torch]
 before_script:


### PR DESCRIPTION
Python 3.6 has been deprecated for a long time now and most libraries still don't support it; Python 3.8/3.9 are now being heavily used in production