### PR TITLE
updated pettingzoo run_rl.py example to work out of the box

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.7", "3.8", "3.9"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
 
     steps:
     - uses: actions/checkout@v2

--- a/examples/pettingzoo/run_rl.py
+++ b/examples/pettingzoo/run_rl.py
@@ -9,10 +9,7 @@ import torch
 from pettingzoo.classic import (
     leduc_holdem_v4,
     texas_holdem_v4,
-    dou_dizhu_v4,
-    mahjong_v4,
     texas_holdem_no_limit_v6,
-    uno_v4,
     gin_rummy_v4,
 )
 from rlcard.agents.pettingzoo_agents import RandomAgentPettingZoo
@@ -29,10 +26,7 @@ from rlcard.utils import (
 env_name_to_env_func = {
     "leduc-holdem": leduc_holdem_v4,
     "limit-holdem": texas_holdem_v4,
-    "doudizhu": dou_dizhu_v4,
-    "mahjong": mahjong_v4,
     "no-limit-holdem": texas_holdem_no_limit_v6,
-    "uno": uno_v4,
     "gin-rummy": gin_rummy_v4,
 }
 
@@ -48,8 +42,7 @@ def train(args):
     # Make the environment with seed
     env_func = env_name_to_env_func[args.env]
     env = env_func.env()
-    env.seed(args.seed)
-    env.reset()
+    env.reset(seed=args.seed)
 
     # Initialize the agent and use random agents as opponents
     learning_agent_name = env.agents[0]

--- a/rlcard/utils/pettingzoo_utils.py
+++ b/rlcard/utils/pettingzoo_utils.py
@@ -21,7 +21,7 @@ def run_game_pettingzoo(env, agents, is_training=False):
     env.reset()
     trajectories = defaultdict(list)
     for agent_name in env.agent_iter():
-        obs, reward, done, _ = env.last()
+        obs, reward, done, _, _ = env.last()
         trajectories[agent_name].append((obs, reward, done))
 
         if done:

--- a/setup.py
+++ b/setup.py
@@ -44,6 +44,7 @@ setuptools.setup(
     extras_require=extras,
     requires_python='>=3.7',
     classifiers=[
+        "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.8",


### PR DESCRIPTION
- Newer versions of pettingzoo have a slightly different api.
- Pettingzoo seems to have deprecated the doudizhu, mahjong, and uno environments.
- Also added python 3.10 & 3.11 to github action tests.

Tested with python 3.11 and pettingzoo 1.22.3