### PR TITLE
Uno game: fix wild card color assignment; fix typos

### DIFF
--- a/rlcard/agents/human_agents/blackjack_human_agent.py
+++ b/rlcard/agents/human_agents/blackjack_human_agent.py
@@ -27,7 +27,7 @@ class HumanAgent(object):
         _print_state(state['raw_obs'], state['raw_legal_actions'], state['action_record'])
         action = int(input('>> You choose action (integer): '))
         while action < 0 or action >= len(state['legal_actions']):
-            print('Action illegel...')
+            print('Action illegal...')
             action = int(input('>> Re-choose action (integer): '))
         return state['raw_legal_actions'][action]
 

--- a/rlcard/agents/human_agents/leduc_holdem_human_agent.py
+++ b/rlcard/agents/human_agents/leduc_holdem_human_agent.py
@@ -27,7 +27,7 @@ class HumanAgent(object):
         _print_state(state['raw_obs'], state['action_record'])
         action = int(input('>> You choose action (integer): '))
         while action < 0 or action >= len(state['legal_actions']):
-            print('Action illegel...')
+            print('Action illegal...')
             action = int(input('>> Re-choose action (integer): '))
         return state['raw_legal_actions'][action]
 

--- a/rlcard/agents/human_agents/limit_holdem_human_agent.py
+++ b/rlcard/agents/human_agents/limit_holdem_human_agent.py
@@ -27,7 +27,7 @@ class HumanAgent(object):
         _print_state(state['raw_obs'], state['action_record'])
         action = int(input('>> You choose action (integer): '))
         while action < 0 or action >= len(state['legal_actions']):
-            print('Action illegel...')
+            print('Action illegal...')
             action = int(input('>> Re-choose action (integer): '))
         return state['raw_legal_actions'][action]
 

--- a/rlcard/agents/human_agents/nolimit_holdem_human_agent.py
+++ b/rlcard/agents/human_agents/nolimit_holdem_human_agent.py
@@ -27,7 +27,7 @@ class HumanAgent(object):
         _print_state(state['raw_obs'], state['action_record'])
         action = int(input('>> You choose action (integer): '))
         while action < 0 or action >= len(state['legal_actions']):
-            print('Action illegel...')
+            print('Action illegal...')
             action = int(input('>> Re-choose action (integer): '))
         return state['raw_legal_actions'][action]
 

--- a/rlcard/agents/human_agents/uno_human_agent.py
+++ b/rlcard/agents/human_agents/uno_human_agent.py
@@ -27,7 +27,7 @@ class HumanAgent(object):
         _print_state(state['raw_obs'], state['action_record'])
         action = int(input('>> You choose action (integer): '))
         while action < 0 or action >= len(state['legal_actions']):
-            print('Action illegel...')
+            print('Action illegal...')
             action = int(input('>> Re-choose action (integer): '))
         return state['raw_legal_actions'][action]
 

--- a/rlcard/games/uno/round.py
+++ b/rlcard/games/uno/round.py
@@ -52,7 +52,7 @@ class UnoRound:
             self.dealer.deal_cards(player, 2)
 
     def proceed_round(self, players, action):
-        ''' Call other Classes's functions to keep one round running
+        ''' Call other Classes' functions to keep one round running
 
         Args:
             player (object): object of UnoPlayer
@@ -65,11 +65,12 @@ class UnoRound:
         card_info = action.split('-')
         color = card_info[0]
         trait = card_info[1]
-        # remove correspongding card
+        # remove corresponding card
         remove_index = None
         if trait == 'wild' or trait == 'wild_draw_4':
             for index, card in enumerate(player.hand):
                 if trait == card.trait:
+                    card.color = color # update the color of wild card to match the action
                     remove_index = index
                     break
         else:


### PR DESCRIPTION
Right now the wild card color gets assigned randomly when it gets drawn from the deck:

```python
        # draw a wild card
        if card.type == 'wild':
            card.color = self.np_random.choice(UnoCard.info['color'])
```

and the player is then able to pick any wild card color:

```python
                        if wild_flag == 0:
                            wild_flag = 1
                            legal_actions.extend(WILD)
```

however, whatever color the player picks, the original random card color gets played. This PR fixes the problem by changing the card color during action execution.

This also makes the dqn training more effective against the random agent. Previous results:
```
0 experiments/uno_dqn_result/model.pth 0.0174
1 random -0.0174
```

After the change:
```
--> Running on the CPU
0 experiments/uno_dqn_result/model.pth 0.0294
1 random -0.0294
```