### PR TITLE
fix bug: doudizhu env seen_cards

### DIFF
--- a/rlcard/games/doudizhu/round.py
+++ b/rlcard/games/doudizhu/round.py
@@ -60,7 +60,7 @@ class DoudizhuRound:
             for c in action:
                 self.played_cards[self.current_player][CARD_RANK_STR_INDEX[c]] += 1
                 if self.current_player == 0 and c in self.seen_cards:
-                    self.seen_cards = self.seen_cards.replace(c, '') 
+                    self.seen_cards = self.seen_cards.replace(c, '', 1) 
                     self.public['seen_cards'] = self.seen_cards
             self.public['played_cards'] = self.cards_ndarray_to_str(self.played_cards)
 


### PR DESCRIPTION
Old: 
when there are duplicate cards in seen_cards, playing one will discard all the cards, which is inconsistent with the three landlord card in DouZero and PerfectDou projects.

Fix: 
only discard one card in seen_cards.