### PR TITLE
Remove unused distutils import to comply with Python3.12

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ experiments/
 dist/
 rlcard/games/doudizhu/jsondata/
 rlcard/agents/gin_rummy_human_agent/gui_cards/cards_png
+.venv/*

--- a/rlcard/agents/__init__.py
+++ b/rlcard/agents/__init__.py
@@ -1,6 +1,5 @@
 import subprocess
 import sys
-from distutils.version import LooseVersion
 
 reqs = subprocess.check_output([sys.executable, '-m', 'pip', 'freeze'])
 installed_packages = [r.decode().split('==')[0] for r in reqs.split()]


### PR DESCRIPTION
No promises that this makes it totally Python3.12 compliant, but removing this one unused distutils import let me run it using Python3.12 locally and pass all tests.